### PR TITLE
Allow 'deleted' status to be pushed with otherProperties

### DIFF
--- a/provider_registration/views.py
+++ b/provider_registration/views.py
@@ -6,7 +6,7 @@ from lxml.etree import XMLSyntaxError
 
 from django.utils import timezone
 from django.shortcuts import render
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.views.decorators.clickjacking import xframe_options_exempt
 
 from provider_registration import utils

--- a/push_endpoint/migrations/0024_deleted_entries.py
+++ b/push_endpoint/migrations/0024_deleted_entries.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+LIST_OF_DOCIDS = [
+    "https://scholarsphere.psu.edu/files/5712mj127",
+    "https://scholarsphere.psu.edu/files/5712mj14s",
+    "https://scholarsphere.psu.edu/files/5712mj152",
+    "https://scholarsphere.psu.edu/files/5712mj16b",
+    "https://scholarsphere.psu.edu/files/5712mj17m",
+    "https://scholarsphere.psu.edu/files/5712mj18w",
+    "https://scholarsphere.psu.edu/files/5712mj195",
+    "https://scholarsphere.psu.edu/files/5712mj20x",
+    "https://scholarsphere.psu.edu/files/5712mj216",
+    "https://scholarsphere.psu.edu/files/5712mj22g",
+    "https://scholarsphere.psu.edu/files/5712mj241",
+    "https://scholarsphere.psu.edu/files/x346dn061",
+    "https://scholarsphere.psu.edu/files/x346dn079",
+    "https://scholarsphere.psu.edu/files/x346dn08k",
+    "https://scholarsphere.psu.edu/files/x346dn09v",
+    "https://scholarsphere.psu.edu/files/x346dn10m",
+    "https://scholarsphere.psu.edu/files/x346dn13f",
+    "https://scholarsphere.psu.edu/files/x346dn14q",
+    "https://scholarsphere.psu.edu/files/x346dn168",
+    "https://scholarsphere.psu.edu/files/x346dn18t",
+    "https://scholarsphere.psu.edu/files/x346dn20v",
+    "https://scholarsphere.psu.edu/files/x346dn214",
+    "https://scholarsphere.psu.edu/files/x346dn24z",
+    "https://scholarsphere.psu.edu/files/x346dn257",
+    "https://scholarsphere.psu.edu/files/x346dn26h",
+    "https://scholarsphere.psu.edu/files/x346dn27s",
+    "https://scholarsphere.psu.edu/files/x346dn282",
+    "https://scholarsphere.psu.edu/files/x346dn29b",
+    "https://scholarsphere.psu.edu/files/x346dn303",
+    "https://scholarsphere.psu.edu/files/x346dn32n",
+    "https://scholarsphere.psu.edu/files/x346dn35g",
+    "https://scholarsphere.psu.edu/files/x346dn371",
+    "https://scholarsphere.psu.edu/files/x346dn389",
+    "https://scholarsphere.psu.edu/files/x346dn39k",
+    "https://scholarsphere.psu.edu/files/x346dn40b",
+    "https://scholarsphere.psu.edu/files/x346dn41m",
+    "https://scholarsphere.psu.edu/files/x346dn42w",
+    "https://scholarsphere.psu.edu/files/x346dn435",
+    "https://scholarsphere.psu.edu/files/x346dn460",
+    "https://scholarsphere.psu.edu/files/x346dn478",
+    "https://scholarsphere.psu.edu/files/x346dn48j",
+    "https://scholarsphere.psu.edu/files/x346dn49t",
+    "https://scholarsphere.psu.edu/files/x346dn50k",
+    "https://scholarsphere.psu.edu/files/x346dn51v",
+    "https://scholarsphere.psu.edu/files/x346dn53d",
+    "https://scholarsphere.psu.edu/files/x346dn54p",
+    "https://scholarsphere.psu.edu/files/x346dn567",
+    "https://scholarsphere.psu.edu/files/x346dn57h",
+    "https://scholarsphere.psu.edu/files/x346dn58s",
+    "https://scholarsphere.psu.edu/files/x346dn592",
+    "https://scholarsphere.psu.edu/files/x346dn60t",
+    "https://scholarsphere.psu.edu/files/x346dn613",
+    "https://scholarsphere.psu.edu/files/x346dn62c",
+    "https://scholarsphere.psu.edu/files/x346dn63n",
+    "https://scholarsphere.psu.edu/files/x346dn64x",
+    "https://scholarsphere.psu.edu/files/x346dn65",
+    "http://osf.io/share9"
+]
+
+
+def update_deleted_documents(apps, schema_editor):
+    # Takes strings, lieral evals them into python Dicts
+    PushedData = apps.get_model("push_endpoint", "PushedData")
+    for item in PushedData.objects.all():
+        if item.jsonData['uris']['providerUris'][0] in LIST_OF_DOCIDS:
+            item.status = 'deleted'
+            item.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_endpoint', '0023_dict_string'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_deleted_documents),
+    ]

--- a/push_endpoint/serializers.py
+++ b/push_endpoint/serializers.py
@@ -40,6 +40,12 @@ class PushedDataSerializer(BulkSerializerMixin, serializers.ModelSerializer):
         if PushedData.objects.filter(source=validated_data['source'].provider.shortname, docID=json_data['uris']['providerUris'][0]).exists():
             validated_data['status'] = 'updated'
 
+        # Look for a status property in otherProperties for "deleted"
+        if json_data.get('otherProperties', None):
+            for prop in json_data['otherProperties']:
+                if prop['properties'].get('status', None) == ['deleted']:
+                    validated_data['status'] = 'deleted'
+
         validated_data['jsonData'] = json_data
         validated_data['docID'] = json_data['uris']['providerUris'][0]
         validated_data['provider'] = validated_data['source'].provider

--- a/templates/rest_framework/api.html
+++ b/templates/rest_framework/api.html
@@ -1,5 +1,4 @@
 {% extends "rest_framework/base.html" %}
-    {% load url from future %}
     {% load rest_framework %}
     {% load static %}
 

--- a/templates/rest_framework/get_api_key.html
+++ b/templates/rest_framework/get_api_key.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load rest_framework %}
 {% load static %}
 


### PR DESCRIPTION
## Changes
- Add migration to remove deleted entries
- Look for deleted status in pushed data in 'otherProperties' field
- Add that status to the outer status
- Add a test to make sure this happens properly
### Unrelated:
- Remove/update a few deprecated imports 
